### PR TITLE
Added missing std::limits declaration to earcut

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
The package fails to compile without this patch as seen here: https://github.com/Groctel/pkgbuilds/blob/main/python-mapbox-earcut/PKGBUILD#L31