### PR TITLE
Drop “message” keyword from pytest.raises(…)

### DIFF
--- a/tests/test_earcut.py
+++ b/tests/test_earcut.py
@@ -74,7 +74,7 @@ def test_end_index_too_large():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([5])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -82,7 +82,7 @@ def test_end_index_too_small():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([2])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -90,7 +90,7 @@ def test_end_index_neg():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([-1])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -98,7 +98,7 @@ def test_rings_not_increasing():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([3, 0, 3])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -106,7 +106,7 @@ def test_rings_same():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([3, 3])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -114,7 +114,7 @@ def test_no_rings():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 
@@ -122,7 +122,7 @@ def test_no_rings():
     verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
     rings = np.array([])
 
-    with pytest.raises(ValueError, message="Expecting ValueError"):
+    with pytest.raises(ValueError):
         result = earcut.triangulate_float32(verts, rings)
 
 


### PR DESCRIPTION
This is not supported in recent pytest (I tried 6.2.2), and the particular messages that were given did not add significant information in case of failure.

Fixes:

```
====================================================== FAILURES ======================================================
______________________________________________ test_end_index_too_large ______________________________________________

    def test_end_index_too_large():
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([5])

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:77: TypeError
______________________________________________ test_end_index_too_small ______________________________________________

    def test_end_index_too_small():
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([2])

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:85: TypeError   
_________________________________________________ test_end_index_neg _________________________________________________

    def test_end_index_neg():
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([-1])

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:93: TypeError   
_____________________________________________ test_rings_not_increasing ______________________________________________

    def test_rings_not_increasing(): 
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([3, 0, 3])  

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:101: TypeError  
__________________________________________________ test_rings_same ___________________________________________________

    def test_rings_same():
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([3, 3])

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:109: TypeError  
___________________________________________________ test_no_rings ____________________________________________________

    def test_no_rings():
        verts = np.array([[0, 0], [1, 0], [1, 1]]).reshape(-1, 2)
        rings = np.array([])

>       with pytest.raises(ValueError, message="Expecting ValueError"):
E       TypeError: Unexpected keyword arguments passed to pytest.raises: message
E       Use context-manager form instead?

tests/test_earcut.py:125: TypeError  
============================================== short test summary info ===============================================
FAILED tests/test_earcut.py::test_end_index_too_large - TypeError: Unexpected keyword arguments passed to pytest.ra...
FAILED tests/test_earcut.py::test_end_index_too_small - TypeError: Unexpected keyword arguments passed to pytest.ra...
FAILED tests/test_earcut.py::test_end_index_neg - TypeError: Unexpected keyword arguments passed to pytest.raises: ...
FAILED tests/test_earcut.py::test_rings_not_increasing - TypeError: Unexpected keyword arguments passed to pytest.r...
FAILED tests/test_earcut.py::test_rings_same - TypeError: Unexpected keyword arguments passed to pytest.raises: mes...
FAILED tests/test_earcut.py::test_no_rings - TypeError: Unexpected keyword arguments passed to pytest.raises: message
============================================ 6 failed, 7 passed in 0.13s =============================================
```