### PR TITLE
Fix out-of-bounds access on empty input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,10 +33,16 @@ py::array_t<IndexT> triangulate(py::array_t<CoordT> vertices, py::array_t<IndexT
     auto r = ring_end_indices.template unchecked<1>();
     const auto num_rings = r.shape(0);
     const auto num_verts = v.shape(0);
-    if (((num_rings > 0) && (r(num_rings - 1) != num_verts)) ||
-        ((num_rings <= 0) && (num_verts > 0)))
+    if (num_rings > 0)
     {
-        throw std::invalid_argument("The last value of ring_end_indices must be equal to the number of vertices!");
+        if (r(num_rings - 1) != num_verts)
+        {
+             throw std::invalid_argument("The last value of ring_end_indices must be equal to the number of vertices!");
+        }
+    }
+    else if (num_verts > 0)
+    {
+       throw std::invalid_argument("ring_end_indices is empty, but vertices is not! This seems like it might not be intentional.");
     }
     using Point = std::array<CoordT, 2>;
     std::vector<std::vector<Point>> polygon;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,8 @@ py::array_t<IndexT> triangulate(py::array_t<CoordT> vertices, py::array_t<IndexT
     auto r = ring_end_indices.template unchecked<1>();
     const auto num_rings = r.shape(0);
     const auto num_verts = v.shape(0);
-    if (r(num_rings - 1) != num_verts)
+    if (((num_rings > 0) && (r(num_rings - 1) != num_verts)) ||
+        ((num_rings <= 0) && (num_verts > 0)))
     {
         throw std::invalid_argument("The last value of ring_end_indices must be equal to the number of vertices!");
     }


### PR DESCRIPTION
Fixes #9.

Replaces #10. Now instead of changing

```cpp
    if (r(num_rings - 1) != num_verts)
```
to

```cpp
    if (num_rings > 0 && r(num_rings - 1) != num_verts)
```

I change it to

```cpp
   if (((num_rings > 0) && (r(num_rings - 1) != num_verts)) ||
       ((num_rings <= 0) && (num_verts > 0)))
```

instead. This is based on the idea that `ring_end_indices` is permitted to be empty if and only if `vertices` is also empty. Boolean operator short-circuiting prevents `r(num_rings - 1)` from being evaluated when `num_rings` is zero. The `num_rings <=0` provides symmetry with `num_rings > 0`, but `num_rings` should never be negative in practice.

This fixes the out-of-bounds access, and the tests still pass..