### PR TITLE
Numpy 2.0 Wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-2019, macos-13]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-22.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -16,10 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
-        env:
-          CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
+        uses: pypa/cibuildwheel@v2.17.0
 
       - name: Show files
         run: ls -lh wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2019, macos-11]
+        os: [ubuntu-24.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.19.2
 
       - name: Show files
         run: ls -lh wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2019, macos-11]
+        os: [ubuntu-latest, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.8"
 authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
 license =  {file = "LICENSE.md"}
 description = "Python bindings for the mapbox earcut C++ polygon triangulation library."
-dependencies = ["numpy>=1.19.0"]
+dependencies = ["numpy>=1.24.0"]
 
 [project.urls]
 Source = "https://github.com/skogler/mapbox_earcut_python"
@@ -33,6 +33,7 @@ test = ["pytest"]
 
 
 [tool.cibuildwheel]
+skip = "pp*"
 # install the `test` extra
 test-extras = ["test"]
 
@@ -44,7 +45,7 @@ test-command = ["pytest {package}/tests",
 		"pytest {package}/tests"]
 
 # don't test on PyPy as it will re-build numpy
-test-skip = "*_arm64 *_universal2:arm64 pp*"
+test-skip = "*_arm64 *_universal2:arm64"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11~=2.6",
-    "numpy>=1.19.0"
+    "pybind11==2.12.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -35,14 +34,16 @@ test = ["pytest"]
 [tool.cibuildwheel]
 # install the `test` extra
 test-extras = ["test"]
+
 # Run the package tests using `pytest`
+# also test against pre-release Numpy
+# TODO : when numpy 2.0 releases this can be reduced to just one pytest
+test-command = ["pytest {package}/tests",
+	        "pip install --force-reinstall --upgrade --pre numpy",
+		"pytest {package}/tests"]
 
-test-command = "pytest {package}/tests && pip install --force-reinstall --upgrade --pre numpy && pytest {package}/tests"
-
-test-skip = "*_arm64 *_universal2:arm64"
-
-# Numpy only builds wheels for very specific versions of PyPy for some reasy
-skip = "pp*"
+# don't test on PyPy as it will re-build numpy
+test-skip = "*_arm64 *_universal2:arm64 pp*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mapbox_earcut"
 version = "1.0.2"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
 license =  {file = "LICENSE.md"}
 description = "Python bindings for the mapbox earcut C++ polygon triangulation library."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11~=2.6",
-    "numpy==1.26.4"
+    "numpy>=1.19.5"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,15 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "pybind11==2.12.0",
+    "pybind11>=2.12.0",
     "tomli>=0.10; python_version<'3.11'",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mapbox_earcut"
-version = "1.0.2"
-requires-python = ">=3.7"
+name = "earcutx"
+version = "1.0.3"
+requires-python = ">=3.8"
 authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
 license =  {file = "LICENSE.md"}
 description = "Python bindings for the mapbox earcut C++ polygon triangulation library."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11~=2.6",
-    "numpy==1.26.4" 
+    "numpy==1.26.4"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11==2.12.0",
+    "tomli>=0.10; python_version<'3.11'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "earcutx"
-version = "1.0.3"
+version = "1.0.4"
 requires-python = ">=3.8"
 authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
 license =  {file = "LICENSE.md"}
@@ -38,11 +38,7 @@ skip = "pp*"
 test-extras = ["test"]
 
 # Run the package tests using `pytest`
-# also test against pre-release Numpy
-# TODO : when numpy 2.0 releases this can be reduced to just one pytest
-test-command = ["pytest {package}/tests",
-	        "pip install --force-reinstall --upgrade --pre numpy",
-		"pytest {package}/tests"]
+test-command = "pytest {package}/tests"
 
 # don't test on PyPy as it will re-build numpy
 test-skip = "*_arm64 *_universal2:arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,18 +3,18 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11~=2.6",
-    "numpy>=1.26.0"
+    "numpy>=1.19.0"
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "mapbox_earcut"
 version = "1.0.2"
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
 license =  {file = "LICENSE.md"}
 description = "Python bindings for the mapbox earcut C++ polygon triangulation library."
-dependencies = ["numpy>=1.26.0"]
+dependencies = ["numpy>=1.19.0"]
 
 [project.urls]
 Source = "https://github.com/skogler/mapbox_earcut_python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ test-extras = ["test"]
 # Run the package tests using `pytest`
 
 test-command = "pytest {package}/tests && pip install --force-reinstall --upgrade --pre numpy && pytest {package}/tests"
-test-skip = "*_arm64 *_universal2:arm64"
+
+test-skip = "*_arm64 *_universal2:arm64 pp*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ test-extras = ["test"]
 
 test-command = "pytest {package}/tests && pip install --force-reinstall --upgrade --pre numpy && pytest {package}/tests"
 
-test-skip = "*_arm64 *_universal2:arm64 pp*"
+test-skip = "*_arm64 *_universal2:arm64"
+
+# Numpy only builds wheels for very specific versions of PyPy for some reasy
+skip = "pp*"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,18 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11~=2.6",
+    "numpy==1.26.4" 
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+# install the `test` extra
+test-extras = ["test"]
+# Run the package tests using `pytest`
+
+test-command = "pytest {package}/tests && pip install --force-reinstall --upgrade --pre numpy && pytest {package}/tests"
+test-skip = "*_arm64 *_universal2:arm64"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,34 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pybind11~=2.6",
-    "numpy>=1.19.5"
+    "numpy>=1.26.0"
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "mapbox_earcut"
+version = "1.0.2"
+requires-python = ">=3.7"
+authors = [{name = "Samuel Kogler", email = "samuel.kogler@gmail.com"}]
+license =  {file = "LICENSE.md"}
+description = "Python bindings for the mapbox earcut C++ polygon triangulation library."
+dependencies = ["numpy>=1.26.0"]
+
+[project.urls]
+Source = "https://github.com/skogler/mapbox_earcut_python"
+CSource = "https://github.com/mapbox/earcut.hpp"
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+
+[project.optional-dependencies]
+test = ["pytest"]
+
 
 [tool.cibuildwheel]
 # install the `test` extra
@@ -17,4 +42,3 @@ test-skip = "*_arm64 *_universal2:arm64"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-

--- a/setup.py
+++ b/setup.py
@@ -1,42 +1,19 @@
-import os
-
 from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-FILE_DIR = os.path.dirname(os.path.abspath(__file__))
-VERSION = '1.0.1'
+# TODO
+VERSION = "1.0.2"
 
 ext_modules = [
-    Pybind11Extension('mapbox_earcut',
-        ['src/main.cpp'],
-        include_dirs=['include'],
-        define_macros = [('VERSION_INFO', VERSION)],
-        ),
+    Pybind11Extension(
+        "mapbox_earcut",
+        ["src/main.cpp"],
+        include_dirs=["include"],
+        define_macros=[("VERSION_INFO", VERSION)],
+    ),
 ]
 
-def get_readme_contents():
-    with open(os.path.join(FILE_DIR, 'README.md'), 'r') as readme_file:
-        return readme_file.read()
-
 setup(
-    name='mapbox_earcut',
-    version=VERSION,
-    url='https://github.com/skogler/mapbox_earcut_python',
-    author='Samuel Kogler',
-    author_email='samuel.kogler@gmail.com',
-    description=
-    'Python bindings for the mapbox earcut C++ polygon triangulation library.',
-    long_description=get_readme_contents(),
-    long_description_content_type='text/markdown',
-    license='ISC',
     ext_modules=ext_modules,
-    install_requires=['numpy'],
-    extras_require={'test': 'pytest'},
     cmdclass=dict(build_ext=build_ext),
-    zip_safe=False,
-    project_urls={
-        'Source': 'https://github.com/skogler/mapbox_earcut_python',
-        'Original C++ Source': 'https://github.com/mapbox/earcut.hpp',
-    },
-    include_package_data = True
 )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,42 @@
+import os
+
 from setuptools import setup
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 
-# TODO
-VERSION = "1.0.2"
+
+def _get_version() -> str:
+    """
+    Get the version defined in `pyproject.toml` to prevent
+    requiring the version to be specified in two places.
+
+    Note that Python only introduced a TOML parser in
+    Python 3.11 so this requires `pip install tomli` for older
+    versions of Python.
+    """
+    try:
+        # we could also do this with
+        # if `sys.version_info >= (3, 11)`
+        from tomllib import load
+    except BaseException:
+        # a parser with the same API from pypi
+        from tomli import load
+
+    # current working directory
+    cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
+    # file-relative pyproject path
+    path = os.path.join(cwd, "pyproject.toml")
+    with open(path, "rb") as f:
+        pyproject = load(f)
+
+    return pyproject["project"]["version"]
+
 
 ext_modules = [
     Pybind11Extension(
         "mapbox_earcut",
         ["src/main.cpp"],
         include_dirs=["include"],
-        define_macros=[("VERSION_INFO", VERSION)],
+        define_macros=[("VERSION_INFO", _get_version())],
     ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def _get_version() -> str:
 
 ext_modules = [
     Pybind11Extension(
-        "mapbox_earcut",
+        "earcutx",
         ["src/main.cpp"],
         include_dirs=["include"],
         define_macros=[("VERSION_INFO", _get_version())],

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,6 @@ PYBIND11_MODULE(mapbox_earcut, m)
     m.def("triangulate_float64", &triangulate<double, uint32_t>);
 
 #ifdef VERSION_INFO
-
     m.attr("__version__") = MACRO_TO_STR(VERSION_INFO) ;
 #else
     m.attr("__version__") = "dev";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,13 +77,13 @@ py::array_t<IndexT> triangulate(py::array_t<CoordT> vertices, py::array_t<IndexT
     );
 }
 
-PYBIND11_MODULE(mapbox_earcut, m)
+PYBIND11_MODULE(earcutx, m)
 {
     m.doc() = R"pbdoc(
         Python bindings to mapbox/earcut.hpp
         -----------------------
 
-        .. currentmodule:: mapbox_earcut
+        .. currentmodule:: earcutx
 
         .. autosummary::
            :toctree: _generate

--- a/tests/test_earcut.py
+++ b/tests/test_earcut.py
@@ -1,4 +1,4 @@
-import mapbox_earcut as earcut
+import earcutx
 import numpy as np
 import pytest
 
@@ -7,10 +7,10 @@ def test_valid_triangulation_float32():
     verts = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float32).reshape(-1, 2)
     rings = np.array([3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (3, )
+    assert result.shape == (3,)
     assert np.all(result == np.array([1, 2, 0]))
 
 
@@ -18,10 +18,10 @@ def test_valid_triangulation_float64():
     verts = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.float64).reshape(-1, 2)
     rings = np.array([3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (3, )
+    assert result.shape == (3,)
     assert np.all(result == np.array([1, 2, 0]))
 
 
@@ -29,23 +29,23 @@ def test_valid_triangulation_int32():
     verts = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.int32).reshape(-1, 2)
     rings = np.array([3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (3, )
+    assert result.shape == (3,)
     assert np.all(result == np.array([1, 2, 0]))
 
 
 def test_inverted_vertex_order():
-    verts = np.array(
-        list(reversed([[0, 0], [1, 0], [1, 1]])), dtype=np.int32).reshape(
-            -1, 2)
+    verts = np.array(list(reversed([[0, 0], [1, 0], [1, 1]])), dtype=np.int32).reshape(
+        -1, 2
+    )
     rings = np.array([3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (3, )
+    assert result.shape == (3,)
     assert np.all(result == np.array([1, 0, 2]))
 
 
@@ -53,20 +53,20 @@ def test_no_triangles():
     verts = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.int32).reshape(-1, 2)
     rings = np.array([2, 3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (0, )
+    assert result.shape == (0,)
 
 
 def test_valid_triangulation_int64():
     verts = np.array([[0, 0], [1, 0], [1, 1]], dtype=np.int64).reshape(-1, 2)
     rings = np.array([3])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
     assert result.dtype == np.uint32
-    assert result.shape == (3, )
+    assert result.shape == (3,)
     assert np.all(result == np.array([1, 2, 0]))
 
 
@@ -75,7 +75,7 @@ def test_end_index_too_large():
     rings = np.array([5])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_end_index_too_small():
@@ -83,7 +83,7 @@ def test_end_index_too_small():
     rings = np.array([2])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_end_index_neg():
@@ -91,7 +91,7 @@ def test_end_index_neg():
     rings = np.array([-1])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_rings_not_increasing():
@@ -99,7 +99,7 @@ def test_rings_not_increasing():
     rings = np.array([3, 0, 3])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_rings_same():
@@ -107,7 +107,7 @@ def test_rings_same():
     rings = np.array([3, 3])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_no_rings():
@@ -115,7 +115,7 @@ def test_no_rings():
     rings = np.array([])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float32(verts, rings)
 
 
 def test_no_rings():
@@ -123,13 +123,13 @@ def test_no_rings():
     rings = np.array([])
 
     with pytest.raises(ValueError):
-        result = earcut.triangulate_float32(verts, rings)
+        result = earcutx.triangulate_float64(verts, rings)
 
 
 def test_empty_data():
     verts = np.array([]).reshape(-1, 2)
     rings = np.array([])
 
-    result = earcut.triangulate_float32(verts, rings)
+    result = earcutx.triangulate_float32(verts, rings)
 
-    assert result.shape == (0, )
+    assert result.shape == (0,)


### PR DESCRIPTION
Thanks for maintaining these bindings!! I'm working on supporting the Numpy 2.0 release and I noticed that the current [wheels + Numpy 2.0](https://github.com/mikedh/trimesh/issues/2216#issuecomment-2101280565) do some funky stuff. I was able to fix it with a simple re-build, although on further investigation I'm not sure why that worked (maybe it used a new pybind11 from my environment?) haha. 

It appears that the minimal thing we need to do is pin `pybind11>=2.12` [which supports both Numpy 1.x and 2.x](https://github.com/pybind/pybind11/pull/5050) and re-build. However I was poking and it looks like tests may not have been running on the wheels so I ended up also changing:

- I moved the cibuildwheel logic and project information into `pyproject.toml` and only left the extension stuff in `setup.py`.
- I don't think cibuildwheel was running tests previously? I added a `test-command` that runs pytest with a default install (Numpy 1.x), and then also tests with a Numpy 2.0 prerelease if one is available for that platform (this did previously fail).
- I changed the build version pin to `pybind11==2.12.0`
- Wheels are [currently building](https://github.com/mikedh/mapbox_earcut_python/actions/runs/9036888850).

If the infrastructure changes are too much I'd be also happy to re-open this as	the minimal PR which would (I think) be:
- pin `pybind11==2.12.0`
- bump version