### PR TITLE
Remove unused variable in earcut.hpp

### DIFF
--- a/include/mapbox/earcut.hpp
+++ b/include/mapbox/earcut.hpp
@@ -263,11 +263,8 @@ void Earcut<N>::earcutLinked(Node* ear, int pass) {
     Node* prev;
     Node* next;
 
-    int iterations = 0;
-
     // iterate through ears, slicing them one by one
     while (ear->prev != ear->next) {
-        iterations++;
         prev = ear->prev;
         next = ear->next;
 


### PR DESCRIPTION
Allow LLVM to compile with `-Wunused-but-set-variable`